### PR TITLE
Update pino-http to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",
   "dependencies": {
-    "pino-http": "^3.0.0"
+    "pino-http": "^3.0.1"
   },
   "devDependencies": {
     "express": "^4.13.4",


### PR DESCRIPTION
As the title says. I would have just done this all on master, but since this module isn't part of the npmjs.com org I wouldn't be able to publish it. Hence the PR.

Also, I looked at updating the Koa logger yesterday and it seems Koa has radically changed since the logger was last published. I'd rather someone who has even a little bit of a clue about Koa deal with that one.