### PR TITLE
[#25] Updates example replacing pino with pino-pretty

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ app.listen(3000)
 ```
 
 ```
-$ node example.js | pino
+$ node example.js | pino-pretty
 [2016-03-31T16:53:21.079Z] INFO (46316 on MBP-di-Matteo): something else
     req: {
       "id": 1,


### PR DESCRIPTION
Fixes #25

## Why is this change necessary?
pino is deprecated as cli
## How does it address the issue?
it uses `pino-pretty` in the example instead.
## What side effects does this change have?
No side effect.