### PR TITLE
Fix example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ without express.
 To our knowledge, `express-pino-logger` is the [fastest](#benchmarks) [express](http://npm.im/express) logger in town.
 
 * [Installation](#install)
-* [Usage](#usage)
+* [Example](#example)
 * [Benchmarks](#benchmarks)
 * [API](#api)
 * [Team](#team)


### PR DESCRIPTION
This PR links to the sample example.

**Why ?**

The current Usage title is broken. When we click on usage it's supposed to take us to the bookmarked page. But it doesn't take us anywhere.  So, I have changed the link to Example. The Example links exists and works properly. 