### PR TITLE
Make links less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An [express](http://npm.im/express) middleware to log with
 [pino](https://github.com/pinojs/pino). Incidentally, it also works
 without express.
 
-To our knowledge, `express-pino-logger` is the [fastest](#benchmarks) [express](http://npm.im/express) logger in town.
+To our knowledge, `express-pino-logger` is the [fastest express](#benchmarks) logger in town.
 
 * [Installation](#install)
 * [Usage](#usage)


### PR DESCRIPTION
I was browsing this package on npmjs.com, when I clicked the link stating "fastest benchmarks" and was redirected to... the npm page for express? I then realized upon further inspection that there were two links in that location, one to the benchmark header and another to the express package. I don't see the value to keeping the link to express there in the first place, considering that most people using this package would know what express is. If that weren't enough, there is already a link to express earlier in the paragraph, so the link here is somewhat redundant.

In addition, npm removes text decoration upon link hover for these links, so it's not immediately clear that there even are two links, unless you're looking carefully.

This is a PR that simply combines the two words into one link for the benchmarks, which IMO is the clearest option.