### PR TITLE
Add notice regarding relation with pino-http

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To our knowledge, `express-pino-logger` is the [fastest express](#benchmarks) lo
 * [Acknowledgements](#acknowledgements)
 * [License](#license)
 
+**Notice**: This is a "meta-package" that only exists for search purposes and internally just exports [`pino-http`](https://github.com/pinojs/pino-http) under a different name without any additional changes or features (see [#41](https://github.com/pinojs/express-pino-logger/issues/41)).
+
 ## Benchmarks
 
 Benchmarks log each request/response pair while returning


### PR DESCRIPTION
Adds a short notice in README about the relation of this package with pino-http. As seen in #41 or #59 this is a bit confusing.

Closes #59.