### PR TITLE
Fixing custom serializers example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm i express-pino-logger --save
 'use strict'
 
 var app = require('express')()
-var pino = require('express-pino-logger')()
+var pino = require('express-pino-logger')
 
 app.use(pino)
 


### PR DESCRIPTION
The current example invokes the ExpressPinoLogger constructor twice, which throws in init:

```
TypeError: Cannot set property 'log' of undefined
    at loggingMiddleware (/repos/app/node_modules/pino-http/logger.js:99:23)
```

Fix for [Incorrect readme.md example #76](https://github.com/pinojs/express-pino-logger/issues/76)