### PR TITLE
Update API options reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ app.use(pino)
 ## API
 
 `express-pino-logger` has the same options of
-[pino](http://npm.im/pino), look at them there.
+[pino-http](http://npm.im/pino-http), look at them there.
 `express-pino-logger` attaches some listeners to the request, so that
 it will log when the request is completed.
 


### PR DESCRIPTION
Hi :)
Since this change:
https://github.com/pinojs/express-pino-logger/pull/5
The exposed API options are the same as in pino-http, so the reference to the API options has to be updated as well
