### PR TITLE
docs: remove redundant `--save` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # express-pino-logger
 [![npm version](https://img.shields.io/npm/v/express-pino-logger)](https://www.npmjs.com/package/express-pino-logger)
 [![Build Status](https://img.shields.io/github/workflow/status/pinojs/express-pino-logger/CI)](https://github.com/pinojs/express-pino-logger/actions)
-[![Known Vulnerabilities](https://snyk.io/test/github/pinojs/express-pino-logger/badge.svg)](https://snyk.io/test/github/pinojs/express-pino-logger)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
 An [express](http://npm.im/express) middleware to log with

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ With `express-pino-logger` you can have features, safety **and** speed.
 ## Install
 
 ```
-npm i express-pino-logger --save
+npm i express-pino-logger
 ```
 
 ## Example


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/3875

Also removes the Snyk badge from the readme, as the `actions/dependency-review-action` does the same thing as Snyk and will replace it.