### PR TITLE
Update example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm i express-pino-logger
 'use strict'
 
 var app = require('express')()
-var pino = require('express-pino-logger')
+var pino = require('express-pino-logger')()
 
 app.use(pino)
 


### PR DESCRIPTION
In order for the `express-pino-logger` middleware to work, it must be called as a function after it is imported.